### PR TITLE
Filter to only fetch public documents by ID

### DIFF
--- a/DocShareAPI/Controllers/Public/PublicDocumentsController.cs
+++ b/DocShareAPI/Controllers/Public/PublicDocumentsController.cs
@@ -218,7 +218,7 @@ namespace DocShareAPI.Controllers.Public
 
             // Fetch all matching documents in a single query
             var documents = await _context.DOCUMENTS
-                .Where(d => validDocumentIDs.Contains(d.document_id))
+                .Where(d => validDocumentIDs.Contains(d.document_id) && d.is_public == true)
                 .Include(d => d.Users)
                 .Select(d => new // Use a DTO for type safety
                 {


### PR DESCRIPTION
Added an is_public check to the document query to ensure only documents that are both in the validDocumentIDs list and marked as public are returned. This prevents non-public documents from being included in the results.